### PR TITLE
fix new-meds-added-to-inactive-list-non-null-rx_list-entries

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -7322,11 +7322,11 @@ class Controller extends BaseController
             'type' => 'textarea',
             'default_value' => $issue['notes']
         ];
-        $items[] = [
-            'name' => 'issue_date_inactive',
-            'type' => 'hidden',
-            'default_value' => $issue['issue_date_inactive']
-        ];
+        // $items[] = [
+        //     'name' => 'issue_date_inactive',
+        //     'type' => 'hidden',
+        //     'default_value' => $issue['issue_date_inactive']
+        // ];
         $items[] = [
             'name' => 'issue_provider',
             'type' => 'hidden',

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -8918,11 +8918,13 @@ class Controller extends BaseController
             'selectpicker' => true,
             'default_value' => $rx['label']
         ];
-        $items[] = [
-            'name' => 'rxl_date_inactive',
-            'type' => 'hidden',
-            'default_value' => $rx['rxl_date_inactive']
-        ];
+        // DH Removed because it causes entry in rx_list
+        // of 0000-00-00. With code commented out entry is null. 
+        // $items[] = [ 
+        //     'name' => 'rxl_date_inactive',
+        //     'type' => 'hidden',
+        //     'default_value' => $rx['rxl_date_inactive']
+        // ];
         $items[] = [
             'name' => 'rxl_provider',
             'type' => 'hidden',
@@ -8934,11 +8936,13 @@ class Controller extends BaseController
             'type' => 'hidden',
             'default_value' => $rx['rxl_date_prescribed']
         ];
-        $items[] = [
-            'name' => 'rxl_date_old',
-            'type' => 'hidden',
-            'default_value' => $rx['rxl_date_old']
-        ];
+        // DH Removed because it causes entry in rx_list
+        // of 0000-00-00. With code commented out entry is null. 
+        // $items[] = [
+        //     'name' => 'rxl_date_old',
+        //     'type' => 'hidden',
+        //     'default_value' => $rx['rxl_date_old']
+        // ];
         if ($subtype !== '') {
             $items[] = [
                 'name' => 'rxl_days',

--- a/resources/lang/en/noshform.php
+++ b/resources/lang/en/noshform.php
@@ -306,7 +306,7 @@ return [
     "partner_name" => "Spouse/Partner Name",
     "employer" => "Employer",
     "ethnicity" => "Ethnicity",
-    "caregiver" => "Careiver(s)",
+    "caregiver" => "Caregiver(s)",
     "status" => "Status",
     "referred_by" => "Referred By",
     "language" => "Preferred Language",

--- a/resources/lang/es/noshform.php
+++ b/resources/lang/es/noshform.php
@@ -306,7 +306,7 @@ return [
     "partner_name" => "Spouse/Partner Name",
     "employer" => "Employer",
     "ethnicity" => "Ethnicity",
-    "caregiver" => "Careiver(s)",
+    "caregiver" => "Caregiver(s)",
     "status" => "Status",
     "referred_by" => "Referred By",
     "language" => "Preferred Language",

--- a/resources/lang/phl/noshform.php
+++ b/resources/lang/phl/noshform.php
@@ -306,7 +306,7 @@ return [
     "partner_name" => "Spouse/Partner Name",
     "employer" => "Employer",
     "ethnicity" => "Ethnicity",
-    "caregiver" => "Careiver(s)",
+    "caregiver" => "Caregiver(s)",
     "status" => "Status",
     "referred_by" => "Referred By",
     "language" => "Preferred Language",


### PR DESCRIPTION
_Expected_ behavior after opening a patient chart, clicking Medications in the left sidebar, clicking "+ Add", entering medication details in the Add Medication form, and pressing "Save": 

1) New medication is added to Active Medication list. 
2) Medications counter in the left sidebar is incremented by one. 

_Actual_ behavior: 

1) New medication is added to Inactive Medication list. 
2) Medication counter in the left sidebar is not incremented. 

_Root cause_ (I think): Adding a new, active medication using this form should insert null in rx_list.rxl_date_inactive and rx_list.rxl_date_old. Instead it inserts '0000-00-00'. 

_Fix_: Remove rx_list.rxl_date_inactive and rx_list.rxl_date_old from the Add Medication form by commenting out the related $items[] arrays in nosh/app/Http/Controllers/Controller.php. 

_Gotchas:_ 

1) Querying datetime fields in mysql tables (e.g. select * from rx_list) will display null for datetime fields which actually contain '0000-00-00'. (I am using the jdbc client version 2.7.1 and DBeaver software. ) However querying this table with 'select * from rx_list where rxl_date_inactive = null' will not retrieve any records containing '0000-00-00'. Querying this table with "select * from rx_list where rxl_date_inactive = '0000-00-00'" _will_ retrieve records containing '0000-00-00'. In other word, a datetime entry of '0000-00-00' displays as null but queries as '0000-00-00'. 

2) Apparently Laravel will insert '0000-00-00' for a hidden datetime entry from a Controller even when $rx = ['rxl_date_inactive' => null] is set. Removing the items from the form seems to fix the problem. 

This proposed edit has been pushed to Docker Hub as dheslinga/nosh:v3. You may test it by modifying docker-compose.yml app-nosh to pull image: dheslinga/nosh:v3 rather than shihjay2/nosh:latest. 

DH
 
